### PR TITLE
Fixes from johpiip

### DIFF
--- a/docs/HSL-mallitoiden_tilaajan_ohje.md
+++ b/docs/HSL-mallitoiden_tilaajan_ohje.md
@@ -13,7 +13,7 @@ Yleistietoa HSL:n Helmet-mallista, sen lähtötiedoista, epävarmuuksista ja tul
 
 ## Mallitöiden tilaaminen
 
-Työohjelmaa laadittaessa ole yhteydessä HSL:n malliasiantuntijoihin (Johanna Piipponen, Mervi Vatanen, Petr Hajduk, Santeri Hiitola).
+Työohjelmaa laadittaessa ole yhteydessä HSL:n liikennemalliasiantuntijoihin.
 Heiltä saat apua mm. lähtötietojen ja skenaarioiden määrittelyyn sekä dokumentointiin.
 Pääsääntöisesti töiden lähtötietoina käytetään HSL:n virallisia aineistoja, joita projekteissa sitten muokataan.
 Pohja-aineiston valinnassa kannattaa ottaa kyseisen projektin tarpeiden lisäksi huomioon myös mahdolliset tarpeet käyttää projektin tuloksia ja koodauksia jatkossa.

--- a/docs/HSL-mallitoiden_tilaajan_ohje.md
+++ b/docs/HSL-mallitoiden_tilaajan_ohje.md
@@ -9,7 +9,7 @@ Tähän on koottu ohjeita HSL:n teettämien mallitöiden tilaamiseen. Ohjeita vo
 
 ## Yleistietoa mallista
 
-Yleistietoa HSL:n Helmet-mallista, sen lähtötiedoista, epävarmuuksista ja tuloksista löydät [täältä](index.md).
+Yleistietoa HSL:n Helmet-mallista, sen lähtötiedoista, epävarmuuksista ja tuloksista löydät [etusivulta](index.md).
 
 ## Mallitöiden tilaaminen
 
@@ -27,7 +27,7 @@ herkkyystarkasteluja tehdään myös edellisen MAL-kierroksen virallisissa verko
 Töiden aloituksessa on huomioitava, että vertailuvaihtoehdon laatiminen vie pari viikkoa.
 
 Työn tilausvaiheessa varmista, että konsultti tuntee ja käyttää HSL:n laatimia
-mallin [käyttö-](mallitoiden_yleisohje.md) ja [dokumentointiohjeita](HSL-toiden_dokumentointi.md).
+mallin [käyttö](mallitoiden_yleisohje.md)- ja [dokumentointiohjeita](HSL-toiden_dokumentointi.md).
 Näitä ohjeita tulee noudattaa, jotta voidaan varmistua mallitarkastelujen tulosten luotettavuudesta sekä hyödynnettävyydestä jatkotarkasteluissa.
 
 Työn valmistuessa varmista, että sen tulokset ja malliaineistot toimitetaan HSL:n malliasiantuntijoille ohjeissa määritellyssä muodossa.

--- a/docs/HSL-toiden_dokumentointi.md
+++ b/docs/HSL-toiden_dokumentointi.md
@@ -35,7 +35,7 @@ Merkinnästä tulee käydä ilmi, mitä kysyntä- ja tarjontakuvauksen tai malli
 Merkitse myös muutosmakro (ems-tiedosto), jolla muutos on toistettavissa ja josta käyvät ilmi käytetyt lukuarvot, tai lähtötietotiedosto, johon muutokset on viety.
 Jos olet lisännyt verkolle solmuja, listaa käyttämäsi uudet solmunumerot.
 HUOM. Virallisia solmuja saa koodata vain, jos siitä sovitaan erikseen HSL:n kanssa.
-Pääsääntönä käytetään aina villejä solmunumeroita (ks. raportti Helsingin seudun liikenteen Emme-verkon kuvaus, joka on saatavilla EXT-Helmet -Teams-ryhmässä).
+Pääsääntönä käytetään aina villejä solmunumeroita (ks. [EMME-verkon kuvaus](emme_verkko.md)).
 Kirjaa muistioon, mistä tiedostoista ja/tai kansioista eri tiedot löytyvät.
 
 Dokumentoi muistioon myös muutosten perustelut.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,9 +28,7 @@ Mallijärjestelmän rakenne on esitetty tarkemmin seuraavassa kuvassa:
 
 ![HELMET-mallijärjestelmän rakenne](images/Helmet-mallijarjestelma.png)
 
-Mallijärjestelmän kysyntämalleja kuvataan tarkemmin raportissa (KORJAA) [Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän kysyntämallit 2020](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).
-
-Mallijärjestelmän tarjontakuvauksista lisätietoa on raportissa Helsingin seudun liikenteen Emme-verkon kuvaus, joka on saatavilla mallin käyttäjien EXT-Helmet -Teams-ryhmässä.
+Mallijärjestelmää kuvataan tarkemmin raportissa (KORJAA) [Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän kysyntämallit 2020](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).
 
 ## HELMET 5 uusia ominaisuuksia
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,8 +129,7 @@ Malli perustuu nykytilan havaintoaineiston valintoihin:
 
 Mallin matemaattinen pohja perustuu diskreetteihin valintamalleihin:
 * Mallijärjestelmä rakentuu useista eri osamalleista, joissa kuvataan logit-malleilla todennäköisyyttä, että päätöksentekijä valitsee tietyn vaihtoehdon (esim. kulkutapa)
-* Teoriapohjaksi ks. esim. Kenneth Trainin e-kirja Discrete Choice Methods with Simulation, ensimmäinen osa luvusta 2 (Properties of Discrete Choice Models), s. 11-23: 
-(https://eml.berkeley.edu/books/choice2.html))
+* Teoriapohjaksi ks. esim. Kenneth Trainin e-kirja "[Discrete Choice Methods with Simulation](https://eml.berkeley.edu/books/choice2.html)" luku 2 ("Properties of Discrete Choice Models") s. 11-23.
 
 Tyypillisesti liikennemallit jakautuvat neljään osaan, jotka on kytketty toisiinsa:
 * _Matkatuotos_ eli matkojen määrät lähtö- ja määräpaikoittain

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ Vaihtoehdoista HSL:n tarjoamissa verkoissa on käytössä ainoastaan nivelbussit
 
 ### Liityntäpysäköinnin mallinnus
 
-Liityntäpysäköinti on tuotu osaksi mallin kulkutapoja. Liityntäpysäköinti tapahtuu kahtena osamatkana, joista ensimmäinen osamatka tehdään autolla ja toinen joukkoliikenteellä. Liityntäpysäköintiä varten malliin on kuvattu seudun liityntäpysäköintilaitokset ja niiden kapasiteetit ja mahdollinen hinta. Liityntäpysäköintilaitokset on kuvattu sentroideina, joiden numeroavaruus on 35 000 - 35 999
+Liityntäpysäköinti on tuotu osaksi mallin kulkutapoja. Liityntäpysäköinti tapahtuu kahtena osamatkana, joista ensimmäinen osamatka tehdään autolla ja toinen joukkoliikenteellä. Liityntäpysäköintiä varten malliin on kuvattu seudun liityntäpysäköintilaitokset ja niiden kapasiteetit ja mahdollinen hinta. Liityntäpysäköintilaitokset on kuvattu sentroideina, joiden numeroavaruus on 35 000 - 35 999.
 
 
 ### Pyöräilyn mallinnus
@@ -118,17 +118,17 @@ Mallin käytettävyyttä on pyritty parantamaan selkeyttämällä virhetilanteid
 ### Mallin oletuksia, perusteluita ja rajoituksia
 
 Oletuksena yksilöiden hyödyn maksimointi:
-* Malli olettaa, että ihmiset ovat tietoisia kaikista vaihtoehdoista ja niiden hyödyistä ja haitoista
-* Malli tekee ainoastaan ihmisten oman hyödyn maksimoivia valintoja
-* Todellisuudessa ihmisten päätöksenteko ei ole näin suoraviivaista ja rationaalista, mutta hyötymaksimointi on mallintamisessa yleisesti käytetty oletus
+* Malli olettaa, että ihmiset ovat tietoisia kaikista vaihtoehdoista ja niiden hyödyistä ja haitoista.
+* Malli tekee ainoastaan ihmisten oman hyödyn maksimoivia valintoja.
+* Todellisuudessa ihmisten päätöksenteko ei ole näin suoraviivaista ja rationaalista, mutta hyötymaksimointi on mallintamisessa yleisesti käytetty oletus.
 
 Malli perustuu nykytilan havaintoaineiston valintoihin:
-* Oletetaan, että tulevaiuusskenaarioissa ihmiset tekevät valintansa samoilla perusteilla kuin havaintoaineistossa eli nykytilassa
-* Ennusteita ei voida tehdä asenteiden muutoksista (jos matka-aikaa, kustannuksia ym. arvostetaan eri tavalla kuin nykyisin)
+* Oletetaan, että tulevaisuusskenaarioissa ihmiset tekevät valintansa samoilla perusteilla kuin havaintoaineistossa eli nykytilassa.
+* Ennusteita ei voida tehdä asenteiden muutoksista (jos matka-aikaa, kustannuksia ym. arvostetaan eri tavalla kuin nykyisin).
 * Radikaaleja muutoksia toimintaympäristössä on haastava ennustaa ja siten mallintaa. Esimerkiksi koronaviruspandemia ja siitä seurannut etätyön lisääntyminen vaikuttaa pysyvästi mallin tuloksiin, mutta sitä ei ole voinut kuvata todenmukaisesti mallilla, joka oli estimoitu pandemiaa edeltävällä liikkumistutkimusaineistolla.
 
 Mallin matemaattinen pohja perustuu diskreetteihin valintamalleihin:
-* Mallijärjestelmä rakentuu useista eri osamalleista, joissa kuvataan logit-malleilla todennäköisyyttä, että päätöksentekijä valitsee tietyn vaihtoehdon (esim. kulkutapa)
+* Mallijärjestelmä rakentuu useista eri osamalleista, joissa kuvataan logit-malleilla todennäköisyyttä, että päätöksentekijä valitsee tietyn vaihtoehdon (esim. kulkutapa).
 * Teoriapohjaksi ks. esim. Kenneth Trainin e-kirja "[Discrete Choice Methods with Simulation](https://eml.berkeley.edu/books/choice2.html)" luku 2 ("Properties of Discrete Choice Models") s. 11-23.
 
 Tyypillisesti liikennemallit jakautuvat neljään osaan, jotka on kytketty toisiinsa:

--- a/docs/kaytto-ohje.md
+++ b/docs/kaytto-ohje.md
@@ -57,12 +57,6 @@ Sovellus asentuu käyttäjän koneelle kansioon `%HOMEPATH%/AppData`. Varsinaine
 kansiossa `AppData\Roaming`. 
 Jos käyttäjällä jostain syystä ei ole pääsyä `AppData`-kansioon, vaihtoehto on sovelluksen lataaminen zip-tiedostona ja purku haluamaansa kansioon.
 
-:exclamation: Projektiasetukset nollautuvat, kun käyttöliittymän päivittää vanhemmasta versiosta
-versioon 4.1 (mm. Kaivoksela-, Tikkurila-versiot). Jos et muista, mitkä vanhat asetukset
-olivatkaan, voit tarkistaa ne polusta
-`C:\Users\KÄYTTÄJÄTUNNUS\AppData\Roaming\Helmet 4\config.json`. Tiedosto aukeaa esimerkiksi
-Notepadilla. Tiedostossa olevat polut syötetään käyttöliittymän projektiasetuksiin.
-
 Kun sovellus käynnistetään ensimmäistä kertaa, se yrittää löytää työasemalta EMME-asennuksen ja ladata 
 [HELMET 5.0 -liikenne-ennustejärjestelmän (model system)](https://github.com/HSLdevcom/helmet-model-system) 
 uusimman version skriptit. Sovellus suorittaa myös komennon `pip install`. 

--- a/docs/kaytto-ohje.md
+++ b/docs/kaytto-ohje.md
@@ -65,9 +65,9 @@ Notepadilla. Tiedostossa olevat polut syötetään käyttöliittymän projektias
 
 Kun sovellus käynnistetään ensimmäistä kertaa, se yrittää löytää työasemalta EMME-asennuksen ja ladata 
 [HELMET 5.0 -liikenne-ennustejärjestelmän (model system)](https://github.com/HSLdevcom/helmet-model-system) 
-uusimman version skriptit. Sovellus suorittaa myös komennon ’pip install’. 
+uusimman version skriptit. Sovellus suorittaa myös komennon `pip install`. 
 Nämä kommennot pyörivät hiljaa taustalla, ja sovellus alkaa reagoida vasta niiden valmistuttua.
 
 EMMEn Python-polussa oleva määrittely saattaa epäonnistua, 
-jos ympäristömuuttujaa ’EMMEPATH’ ei ole määritelty tai jos sovellus on asennettu epätavallisella tavalla. Jos näin käy, suorituskelpoisen 
-Python-kielen ja kansion Scripts sijainti on määriteltävä manuaalisesti Asetukset-valikosta.
+jos ympäristömuuttujaa `EMMEPATH` ei ole määritelty tai jos sovellus on asennettu epätavallisella tavalla. Jos näin käy, suorituskelpoisen 
+Python-kielen ja Scripts-kansion sijainti on määriteltävä manuaalisesti Asetukset-valikosta.

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -64,7 +64,7 @@ Taustatietoa verkkokuvausten muodostamisesta ja historiasta löydät raportista 
 
 Kansio sisältää kullekin tarkasteluvuodelle/skenaariolle alikansion, jossa on lähtötiedot mm. maankäytön ja kustannusten osalta.
 Kunkin tiedoston alussa on kuvattu mitä tiedosto sisältää ja mistä tiedot tulevat.
-Kansiossa on oltava yksi kappale kustakin tiedostotyypista .cco, .edu, .ext, .lnd, .pop, .prk, .tco, .trk sekä .wrk.
+Kansiossa on oltava yksi kappale kustakin tiedostotyypista .cco, .edu, .ext, .lnd, .pop, .pnr, .prk, .tco, .trk sekä .wrk.
 Tiedostojen nimillä ei ole merkitystä, ja ne voivat poiketa toisistaan (kansiossa voi esim. olla 2023.pop ja 2023_b.wrk)
 
 **Tiedostot**

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -11,9 +11,8 @@ HSL ylläpitää lähtötietoaineistoja MAL-suunnittelun ja joukkoliikennesuunni
 Aineistojen nimissä on yleensä jokin vuosiskenaario, mutta ennusteet eivät koskaan kuvaa tarkkaa vuotta, vaan tiettyä hankkeiden,
 maankäyttöjen ja muiden lähtötietojen yhdistelmää.
 
-Tässä on kuvattu yleisesti HSL:n ylläpitämiä lähtötietoaineistoja.
-Ohjeita aineistojen lataamiseen ja käyttöön löydät [täältä](mallitoiden_yleisohje.md) ja tarkemman kuvauksen
-aineistojen rakenteesta [täältä](mallin_lahtotietotiedostot.md).
+Tässä on kuvattu yleisesti HSL:n ylläpitämiä lähtötietoaineistoja ja niiden rakennetta.
+Ohjeita aineistojen lataamiseen ja käyttöön löydät "[Mallijärjestelmän käyttö](mallitoiden_yleisohje.md)"-sivulta.
 
 ## Ennusteskenaarioiden syöttötiedot (maankäyttö, kustannukset ym)
 
@@ -63,7 +62,7 @@ Verkkokuvausperiaatteita on kuvattu tarkemmin raportissa Helsingin seudun liiken
 joka on saatavilla mallin käyttäjien EXT-Helmet -Teams-ryhmässä.
 Noudatathan näitä periaatteita verkonkuvauksia koodatessa, jotta varmistutaan tulosten oikeellisuudesta ja aineistojen yhteiskäyttöisyydestä. 
 
-Lisätietoja mallin käyttämisestä [täällä](mallitoiden_yleisohje.md).
+Lisätietoja mallin käyttämisestä "[Mallijärjestelmän käyttö](mallitoiden_yleisohje.md)"-sivulla.
 Taustatietoa verkkokuvausten muodostamisesta ja historiasta löydät raportista [Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän tarjontamallit 2017](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2019/helsingin-seudun-tyossakayntialueen-liikenne-ennustejarjestelman-tarjontamallit-6-2019.pdf).
 
 
@@ -123,7 +122,7 @@ Kansio sisältää kullekin tarkasteluvuodelle/skenaariolle alikansion, jossa on
 * **extra_nodes_xxx.txt** = solmun korkeustaso
 * **extra_transit_lines_xxx.txt** = joukkoliikennelinjojen vuorovälit eri aikajaksoilla (aht, pt, iht)
 
-Skenaariot voi muodostaa kootusti Modellerissa, tarkempi kuvaus [täällä](sijopankki.md). 
+Skenaariot voi muodostaa kootusti Modellerissa "[Sijoittelupankin perustaminen](sijopankki.md)"-sivun ohjeiden mukaan.
 Moduuli ajaa myös sisään seuraavat kaikille skenaarioille yhteiset tiedot:
 
 * **modes_xxx.txt** auto- ja pyöräverkon kulkutavat
@@ -133,11 +132,8 @@ Moduuli ajaa myös sisään seuraavat kaikille skenaarioille yhteiset tiedot:
 
 Lähtötietoja voi muokata joko suoraan lähtötietotiedostoihin tai Emme-ohjelmiston (Modeller, Network Editor, Prompt) kautta.
 
-Verkkokuvausperiaatteita on kuvattu tarkemmin [täällä](emme_verkko.md).
+Verkkokuvausperiaatteita on kuvattu tarkemmin "[EMME-verkon kuvaus](emme_verkko.md)" -sivulla.
 Noudatathan näitä periaatteita verkonkuvauksia koodatessa, jotta varmistutaan tulosten oikeellisuudesta ja aineistojen yhteiskäyttöisyydestä.
-
-Lisätietoja mallin käyttämisestä [täällä](mallitoiden_yleisohje.md).
-Taustatietoa verkkokuvausten muodostamisesta ja historiasta löydät raportista [Helsingin seudun työssäkäyntialueen  liikenne-ennustejärjestelmän tarjontamallit 2017](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2019/helsingin-seudun-tyossakayntialueen-liikenne-ennustejarjestelman-tarjontamallit-6-2019.pdf).
 
 ## Lähtötietojen vaikutus ennustemallin eri osiin
 

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -22,7 +22,7 @@ HSL:n virallisia kysyntämallin lähtötietoja ylläpitää Santeri Hiitola.
 * Nykytilan kuvaus
 * MAL-suunnitelman tavoitevuoden skenaario
 * MAL-suunnitelman pitkän aikavälin tavoiteskenaario
-* MAL-suunnitelman mukaiset välivuosiskenaariot (5 vuoden välein)
+* Välivuosiskenaario
 
 Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saat käyttöoikeuden täyttämällä hakemuslomakkeen EXT-helmet-Teams-ryhmässä.
 Tiedostopolun juuren on dokumentit sisältävät aineistojen yleiskuvauksen,
@@ -35,8 +35,8 @@ Kysyntämalleja on kuvattu tarkemmin raportissa [Helsingin seudun työssäkäynt
 HSL:n virallisia tarjontamallin lähtötietoja ylläpitää Mervi Vatanen.
 
 Vuosittain päivitetään tuore nykytilan kuvaus sekä mahdolliset muutokset tulevien vuosien kuvauksiin HSL:n ja kuntien tuottamiin suunnitelmiin perustuen.
-Päivitetyt versiot julkaistaan aina alkusyksystä. Verkkojen vuosipäivityksiä laaditaan vuosittain kuvaamaan kunkin syksyn liikennetilannetta HSL-liikenteessä. 
 Muutostyö käynnistyy tammikuussa Liikennöintisuunnitelman hyväksymisen jälkeen, ja viimeistellään kesällä, kun kaikki syksyn muutokset ovat varmistuneet.
+Päivitetyt versiot julkaistaan syksyisin. Verkkojen vuosipäivityksiä laaditaan vuosittain kuvaamaan kunkin syksyn liikennetilannetta HSL-liikenteessä. 
 Tässä yhteydessä samat muutokset kuvataan myös MAL-verkkojen päivitettäviin versioihin sekä välivuosien verkoille.
 Lisäksi tulevaisuuden verkkoihin viedään tiedot esim. valmistuneiden linjastosuunnitelmien tuomista muutoksista. 
 
@@ -50,7 +50,7 @@ Laajempia muutoksia tehdään MAL-suunnittelun yhteydessä n. neljän vuoden vä
 * Nykytilan kuvaus
 * MAL-suunnitelman tavoitevuoden skenaario
 * MAL-suunnitelman pitkän aikavälin tavoiteskenaario
-* MAL-suunnitelman mukaiset välivuosiskenaariot (5 vuoden välein)
+* Välivuosiskenaario
 
 Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saat käyttöoikeuden täyttämällä hakemuslomakkeen EXT-helmet-Teams-ryhmässä.
 Kullekin vuodelle on oma alikansionsa ja niistä löytyy readme-tiedostot, joissa on selostettu yleiskuvaus aineistosta.

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -16,8 +16,6 @@ Ohjeita aineistojen lataamiseen ja käyttöön löydät "[Mallijärjestelmän k�
 
 ## Ennusteskenaarioiden syöttötiedot (maankäyttö, kustannukset ym)
 
-HSL:n virallisia kysyntämallin lähtötietoja ylläpitää Santeri Hiitola. 
-
 **Lähtötietoja tuotetaan MAL-suunnittelun yhteydessä n. neljän vuoden välein seuraaville skenaarioille:**
 * Nykytilan kuvaus
 * MAL-suunnitelman tavoitevuoden skenaario
@@ -31,8 +29,6 @@ ja tarkempia tietoja löytyy kunkin tiedoston sisältä kommmentteina.
 Kysyntämalleja on kuvattu tarkemmin raportissa [Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän kysyntämallit 2020](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).
 
 ## Verkkokuvaukset
-
-HSL:n virallisia tarjontamallin lähtötietoja ylläpitää Mervi Vatanen.
 
 Vuosittain päivitetään tuore nykytilan kuvaus sekä mahdolliset muutokset tulevien vuosien kuvauksiin HSL:n ja kuntien tuottamiin suunnitelmiin perustuen.
 Muutostyö käynnistyy tammikuussa Liikennöintisuunnitelman hyväksymisen jälkeen, ja viimeistellään kesällä, kun kaikki syksyn muutokset ovat varmistuneet.
@@ -55,8 +51,8 @@ Laajempia muutoksia tehdään MAL-suunnittelun yhteydessä n. neljän vuoden vä
 Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saat käyttöoikeuden täyttämällä hakemuslomakkeen EXT-helmet-Teams-ryhmässä.
 Kullekin vuodelle on oma alikansionsa ja niistä löytyy readme-tiedostot, joissa on selostettu yleiskuvaus aineistosta.
 
-Ilmoitathan Merville, mikäli havaitset tarjontakuvauksissa puutteita tai korjaustarpeita.
-Mervi ylläpitää korjaustarvelistaa sekä tarjontamallin lähtötietojen tarkempia kuvauksia.
+Ilmoitathan, mikäli havaitset tarjontakuvauksissa puutteita tai korjaustarpeita.
+HSL ylläpitää korjaustarvelistaa sekä tarjontamallin lähtötietojen tarkempia kuvauksia.
 
 Verkkokuvausperiaatteita on kuvattu tarkemmin raportissa Helsingin seudun liikenteen Emme-verkon kuvaus,
 joka on saatavilla mallin käyttäjien EXT-Helmet -Teams-ryhmässä.

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -52,7 +52,7 @@ Laajempia muutoksia tehdään MAL-suunnittelun yhteydessä n. neljän vuoden vä
 * MAL-suunnitelman pitkän aikavälin tavoiteskenaario
 * MAL-suunnitelman mukaiset välivuosiskenaariot (5 vuoden välein)
 
-Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saat käyttöoikeuden täyttämällä hakemuslomakkeen EXT-Helmet -Teams-ryhmässä.
+Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saat käyttöoikeuden täyttämällä hakemuslomakkeen EXT-helmet-Teams-ryhmässä.
 Kullekin vuodelle on oma alikansionsa ja niistä löytyy readme-tiedostot, joissa on selostettu yleiskuvaus aineistosta.
 
 Ilmoitathan Merville, mikäli havaitset tarjontakuvauksissa puutteita tai korjaustarpeita.
@@ -94,7 +94,7 @@ Pysäköintinormit vaikuttavat vain uusien asukkaiden autonomistukseen.
 * **pnr** = liityntäpysäköintilaitosten kapasiteetti ja 12 tunnin hinta
 * **prk** = kunkin ennustealueen työpaikan ja asiointimatkojen pysäköintikustannukset
 * **tco** = joukkoliikenteen kuukausikustannukset eri vyöhykkeillä
-* **trk** = rekkaliikenteen lähtötiedot: yhdistelmäajoneuvoilta kielletyt ennustealueet ja jätteenkäsittelylaitosten ennustealueet
+* **trk** = raskaan liikenteen lähtötiedot: yhdistelmäajoneuvoilta kielletyt ennustealueet ja jätteenkäsittelylaitosten ennustealueet
 * **wrk** = kunkin ennustealueen kokonaistyöpaikkamäärä sekä eri alojen työpaikkojen osuudet (palvelut, kaupat, logistiikka, teollisuus)
 
 ### Lähtödata

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -29,8 +29,8 @@ ja tarkempia tietoja löytyy kunkin tiedoston sisältä kommmentteina.
 ## Verkkokuvaukset
 
 Vuosittain päivitetään tuore nykytilan kuvaus sekä mahdolliset muutokset tulevien vuosien kuvauksiin HSL:n ja kuntien tuottamiin suunnitelmiin perustuen.
-Muutostyö käynnistyy tammikuussa Liikennöintisuunnitelman hyväksymisen jälkeen, ja viimeistellään kesällä, kun kaikki syksyn muutokset ovat varmistuneet.
 Päivitetyt versiot julkaistaan syksyisin. Verkkojen vuosipäivityksiä laaditaan vuosittain kuvaamaan kunkin syksyn liikennetilannetta HSL-liikenteessä. 
+Muutostyö käynnistyy tammikuussa HSL:n Liikennöintisuunnitelman hyväksymisen jälkeen, ja viimeistellään kesällä, kun kaikki syksyn muutokset ovat varmistuneet.
 Tässä yhteydessä samat muutokset kuvataan myös MAL-verkkojen päivitettäviin versioihin sekä välivuosien verkoille.
 Lisäksi tulevaisuuden verkkoihin viedään tiedot esim. valmistuneiden linjastosuunnitelmien tuomista muutoksista. 
 

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -26,8 +26,6 @@ Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saa
 Tiedostopolun juuren on dokumentit sisältävät aineistojen yleiskuvauksen,
 ja tarkempia tietoja löytyy kunkin tiedoston sisältä kommmentteina.
 
-Kysyntämalleja on kuvattu tarkemmin raportissa [Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän kysyntämallit 2020](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).
-
 ## Verkkokuvaukset
 
 Vuosittain päivitetään tuore nykytilan kuvaus sekä mahdolliset muutokset tulevien vuosien kuvauksiin HSL:n ja kuntien tuottamiin suunnitelmiin perustuen.
@@ -54,8 +52,7 @@ Kullekin vuodelle on oma alikansionsa ja niistä löytyy readme-tiedostot, joiss
 Ilmoitathan, mikäli havaitset tarjontakuvauksissa puutteita tai korjaustarpeita.
 HSL ylläpitää korjaustarvelistaa sekä tarjontamallin lähtötietojen tarkempia kuvauksia.
 
-Verkkokuvausperiaatteita on kuvattu tarkemmin raportissa Helsingin seudun liikenteen Emme-verkon kuvaus,
-joka on saatavilla mallin käyttäjien EXT-Helmet -Teams-ryhmässä.
+Verkkokuvausperiaatteita on kuvattu tarkemmin sivulla "[EMME-verkon kuvaus](https://hsldevcom.github.io/helmet-docs-h5/emme_verkko.html)".
 Noudatathan näitä periaatteita verkonkuvauksia koodatessa, jotta varmistutaan tulosten oikeellisuudesta ja aineistojen yhteiskäyttöisyydestä. 
 
 Lisätietoja mallin käyttämisestä "[Mallijärjestelmän käyttö](mallitoiden_yleisohje.md)"-sivulla.

--- a/docs/mallin_lahtotietotiedostot.md
+++ b/docs/mallin_lahtotietotiedostot.md
@@ -24,8 +24,8 @@ HSL:n virallisia kysyntämallin lähtötietoja ylläpitää Santeri Hiitola.
 * MAL-suunnitelman pitkän aikavälin tavoiteskenaario
 * MAL-suunnitelman mukaiset välivuosiskenaariot (5 vuoden välein)
 
-Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saat käyttöoikeuden täyttämällä hakemuslomakkeen EXT-Helmet -Teams-ryhmässä.
-Tiedostopolun juuressa on dokumentti (esim. MAL2019-ennusteet.docx), joka sisältää aineistojen yleiskuvauksen,
+Aineistojen sisältöjä on kuvattu tarkemmin aineiston jakokansiossa, johon saat käyttöoikeuden täyttämällä hakemuslomakkeen EXT-helmet-Teams-ryhmässä.
+Tiedostopolun juuren on dokumentit sisältävät aineistojen yleiskuvauksen,
 ja tarkempia tietoja löytyy kunkin tiedoston sisältä kommmentteina.
 
 Kysyntämalleja on kuvattu tarkemmin raportissa [Helsingin seudun työssäkäyntialueen liikenne-ennustejärjestelmän kysyntämallit 2020](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).
@@ -113,10 +113,8 @@ Kansio sisältää kullekin tarkasteluvuodelle/skenaariolle alikansion, jossa on
 
 **Tiedostot**
 
-* **base_network_xxx.txt** = liikenneverkon solmut ja linkit sekä niiden attribuutit (HUOM: Helmet 5 käyttää myös solmun label-attribuuttia, jossa lippuvyöhykkeen kirjain)
+* **base_network_xxx.txt** = liikenneverkon solmut ja linkit sekä niiden attribuutit
 * **transit_lines_xxx.txt** = joukkoliikennelinjaston kuvaus: mm. linjatunnus, kulkumuoto, ajoneuvotyyppi (vehicle), reitin otsikko, reitin käyttämät solmut
-  (HUOM: pysähtymiset lasketaan solmujen tietojen perusteella ennusteprosessin aikana ja eri aikajaksojen vuorovälit ajetaan sisään
-  erillisestä tiedostosta `extra_transit_lines_xxx.txt`)
 * **turns_xxx.txt** = kääntymiskiellot eri solmujen välillä
 * **extra_links_xxx.txt** = linkkikohtainen tienkäyttömaksu eri aikajaksoilla (aht, pt, iht), pyörätieluokka eri linkeillä, linkin kaltevuus
 * **extra_nodes_xxx.txt** = solmun korkeustaso

--- a/docs/mallitoiden_yleisohje.md
+++ b/docs/mallitoiden_yleisohje.md
@@ -9,20 +9,18 @@ On tärkeää, että mallia käytetään ja muokataan yhtenäisillä periaatteil
 Näin saadaan mahdollisimman luotettavia tuloksia, ja mahdollistetaan aineistojen  hyödyntäminen myös muissa projekteissa. 
 Myös työn huolellinen dokumentointi on tärkeää, sillä se auttaa aineistojen tulkinnassa ja myöhemmässä hyödyntämisessä. 
 
-Mallin käyttämiä lähtötietoja on kuvattu [täällä](mallin_lahtotietotiedostot.md). 
-HSL:n lähtötietoaineistot (mm. maankäytöt ja verkkojen tiedot) saat ladattua zip-pakettina, kun olet täyttänyt aineistojen luovutuksen hakemuslomakkeen.
-Näistä löydät yleistietoa [täältä](mallin_lahtotietotiedostot.md).
-Hakemuslomake löytyy Teams-ryhmästä EXT-Helmet, jonne saat käyttöoikeuden HSL:n Liikennejärjestelmäyksiköstä (Johanna Piipponen).
+HSL:n [lähtötietoaineistot](mallin_lahtotietotiedostot.md) (mm. maankäytöt ja verkkojen tiedot) saat ladattua zip-pakettina, kun olet täyttänyt aineistojen luovutuksen hakemuslomakkeen.
+Hakemuslomake löytyy HSL:n Teams-ryhmästä EXT-Helmet, jonne saat käyttöoikeuden HSL:n Liikennejärjestelmäyksiköstä ([liikennemalli@hsl.fi](mailto:liikennemalli@hsl.fi)).
 Kutakin projektia varten tulee hakea uudet aineistot, jotta aineistojen käyttöä voidaan seurata sekä varmistutaan, että lähtötiedot ovat aina ajan tasalla.
 
-Mallin asennusohjeet löydät [täältä](kaytto-ohje.md), ja EMME-pankin perustamisen ohjeet [täältä](sijopankki.md).
+Voit aloittaa malliprojektin seuraamalla "[Asennus](kaytto-ohje.md)"- ja "[Sijoittelupankin perustaminen](sijopankki.md)" -ohjeita.
 Kutakin projektia varten kannattaa luoda yksi yhteinen EMME-pankki, johon kootaan eri HELMET-skenaariot (esim. eri linjastovaihtoehdot).
 Pääosin suositellaan käytettäväksi vain HSL:n julkaisemia skriptejä ja näiden oletusparametrejä.
-Poikkeamat näihin on syytä dokumentoida huolella (ks. [dokumentointiohje](HSL-toiden_dokumentointi.md)).
+Poikkeamat näihin on syytä dokumentoida huolella (ks. [HSL:n mallitöiden dokumentointiohje](HSL-toiden_dokumentointi.md)).
 
 ## Malliajojen ohje
 
-HELMET-käyttöliittymän (UI) kautta pääset määrittämään projektin asetukset ja lähtötiedot. HELMET-käyttöliittymä on saatavilla [täältä](https://github.com/HSLdevcom/helmet-ui)
+HELMET-käyttöliittymän kautta pääset määrittämään projektin asetukset ja lähtötiedot. Käyttöliittymän asennusohjeet löydät sivulta [Asennus -> HELMET-asennus](https://hsldevcom.github.io/helmet-docs-h5/kaytto-ohje.html#helmet-asennus).
 
 ### Asetukset
 
@@ -43,14 +41,14 @@ Mallin ajoa varten tulee määritellä seuraavat asetukset.
   - Tämä **ei** siis viittaa EMMEn projektitiedostoon (.emp)
 - Lähtödatan sisältävä kansio
   - Tässä ovat omissa alakansioissaan pohjakysyntämatriisit ja nykytilanteen syöttötiedot (2018)
-  - Kansion sisällön saa HSL:ltä (ks. [lähtötietotiedostojen ohje](mallin_lahtotietotiedostot.md))
+  - Kansion sisällön saa HSL:ltä (ks. [Lähtötiedot](mallin_lahtotietotiedostot.md))
 - Tulosten tallennuspolku
   - Tänne talletetaan ennusteajojen tulokset
 
 Näiden asetusten lisäksi on kehittäjille tarkoitettuja asetuksia helmet-model-system -kansion tiedostossa `dev-config.json`.
 Tyypillisesti tavallisilla käyttäjillä ei ole tarvetta muokata näitä lisäasetuksia, mutta joissain käyttötapauksissa voi olla hyötyä myös sellaisista asetuksista, joita ei ole vielä implementoitu käyttöliittymään.
 Lisää tietoja `dev-config.json`-tiedoston asetuksista löytyy 
-[tästä](https://github.com/HSLdevcom/helmet-model-system/tree/olusanya/Scripts#configuring-the-model-run-with-dev-configjson).
+[Scripts-kansion README-tiedostosta](https://github.com/HSLdevcom/helmet-model-system/tree/olusanya/Scripts#configuring-the-model-run-with-dev-configjson).
 
 ### Malliajon määrittely
 
@@ -91,15 +89,15 @@ H/K-analyysillä voidaan verrata ajettujen skenaarioiden hyötyjä ja kustannuks
 1. Vertailuvaihtoehdon (ve0) tuloskansio (`Tulosten tallennuspolku\Skenaarion nimi`)
 2. Hankevaihtoehdon (ve1) tuloskansio
 
-Jos ennusteita on ajettu kahdelle vuodelle (esim. 2040 ja 2060), vertailuvaihtoehto ja hankevaihtoehto on mahdollista määrittää toisellekin ennustevuodelle. Lisätietoa H/K laskennasta ja vaikutustenarvioinnista löytyy [täältä](vaikutusten_arvionti.md).
+Jos ennusteita on ajettu kahdelle vuodelle (esim. 2040 ja 2060), vertailuvaihtoehto ja hankevaihtoehto on mahdollista määrittää toisellekin ennustevuodelle. Lisätietoa H/K-laskennasta ja vaikutusten arvioinnista on "[Vaikutusten arviointi](vaikutusten_arvionti.md)" -sivulla.
 
 ## Tulosten käsittely ja tulkinta
 
-Lisätietoa mallin tuottamista tulostiedostoista ja tulosten tulkinnasta [täällä](tulokset.md).
-Esimerkkejä mallituloksista tehtävistä visualisoinneista [täällä](esimerkkeja_tuloksista.md).
+Voit lukea lisätietoa mallin tuottamista tulostiedostoista ja tulosten tulkinnasta [Tulokset](tulokset.md)-sivulla ja
+esimerkkejä mallituloksista tehtävistä visualisoinneista [Esimerkkejä tuloksista](esimerkkeja_tuloksista.md)-sivulla.
 
 ## Dokumentointi ja aineistojen luovutus
 
 Työn lopuksi kannattaa dokumentoida huolella tehdyt muutokset. 
 Yleensä työn tilaajalla on tietyt toiveet siitä, millaiset dokumentit mallitöistä halutaan. 
-HSL:n tilaamissa töissä kaikki tehdyt muutokset tulee dokumentoida ja aineistot luovuttaa [tämän ohjeen](HSL-toiden_dokumentointi.md) mukaan.  
+HSL:n tilaamissa töissä kaikki tehdyt muutokset tulee dokumentoida ja aineistot luovuttaa [HSL:n mallitöiden dokumentointiohjeen](HSL-toiden_dokumentointi.md) mukaan.  

--- a/docs/mallitoiden_yleisohje.md
+++ b/docs/mallitoiden_yleisohje.md
@@ -40,7 +40,7 @@ Mallin ajoa varten tulee määritellä seuraavat asetukset.
   - Tänne talletetaan HELMET-skenaarioiden (malliajojen) määrittelyt (.json)
   - Tämä **ei** siis viittaa EMMEn projektitiedostoon (.emp)
 - Lähtödatan sisältävä kansio
-  - Tässä ovat omissa alakansioissaan pohjakysyntämatriisit ja nykytilanteen syöttötiedot (2018)
+  - Tässä ovat omissa alakansioissaan pohjakysyntämatriisit ja nykytilanteen syöttötiedot (2023)
   - Kansion sisällön saa HSL:ltä (ks. [Lähtötiedot](mallin_lahtotietotiedostot.md))
 - Tulosten tallennuspolku
   - Tänne talletetaan ennusteajojen tulokset

--- a/docs/mallitoiden_yleisohje.md
+++ b/docs/mallitoiden_yleisohje.md
@@ -52,11 +52,11 @@ Lisää tietoja `dev-config.json`-tiedoston asetuksista löytyy
 
 ### Malliajon määrittely
 
-Jokaista ajettavaa HELMET-skenaariota kohden on tehtävä seuraavat määrittelyt:
+Käyttöliittymässä on tehtävä seuraavat määrittelyt jokaista ajettavaa HELMET-skenaariota kohden:
 
 1.	Skenaarion tai ajon nimi
     - *Skenaario* ei tässä viittaa EMME-skenaarioon, vaan tässä annetaan nimi verkkokuvaus- ja maankäyttötietoyhdistelmälle joka menee yhteen malliajoon.
-2.	EMMEn project-tiedosto (.emp)
+2.	EMMEn project-tiedosto (`.emp`)
 3.	EMME-skenaarion numero. 
    Asetuksista riippuen sijoittelutulokset tallennetaan tähän skenaarioon tai erikseen seuraavaan neljään skenarioon (vrk, aht, pt, iht).
 4.	Kansio, jossa ovat syöttötiedot
@@ -84,7 +84,7 @@ Jokaista ajettavaa HELMET-skenaariota kohden on tehtävä seuraavat määrittely
 
 ### Hyöty-kustannusanalyysin (hankearvioinnin) määrittely
 
-H/K-analyysillä voidaan verrata ajettujen skenaarioiden hyötyjä ja kustannuksia. Tulokset tulostuvat excel-tiedostoon tuloskansiossa. Analyysia varten on määriteltävä:
+H/K-analyysillä voidaan verrata ajettujen skenaarioiden hyötyjä ja kustannuksia. Tulokset tulostuvat Excel-tiedostoon tuloskansiossa. Analyysia varten on määriteltävä:
 
 1. Vertailuvaihtoehdon (ve0) tuloskansio (`Tulosten tallennuspolku\Skenaarion nimi`)
 2. Hankevaihtoehdon (ve1) tuloskansio

--- a/docs/sijopankki.md
+++ b/docs/sijopankki.md
@@ -56,7 +56,7 @@ Perusta tyhjä skenaario kohdassa _First scenario_:
 -	Title: esim. 2018_20211130
 
 Valitse koordinaatisto:
--	Spatial reference: Edit - ETRS89 / GK25FIN (Ei ETRS89 / ETRS-GK25FIN)
+-	Spatial reference: Edit - **ETRS89 / GK25FIN** (ei ETRS89 / ETRS-GK25FIN)
 -	Tarkenna kartta Helsingin kantakaupungin alueelle, jotta UTM-vyöhyke menee muotoon 35N
 - Koordinaatistoa voi myöhemmin muuttaa valikossa File - Project Settings – GIS.
 

--- a/docs/sijopankki.md
+++ b/docs/sijopankki.md
@@ -64,7 +64,7 @@ Valitse koordinaatisto:
 
 Verkkojen sisäänajo tapahtuu Modeller-työkalun kautta (Tools - Modeller...). 
 HSL:n tarjoamien valmiiden lähtötietojen osalta tarvittavat aineistot eri tarkasteluvuosille löytyvät jakokansiosta
-`Verkot` (lisätietoja [täällä](mallin_lahtotietotiedostot.md)).
+"Verkot" (lisätietoja [Lähtötiedot](mallin_lahtotietotiedostot.md)-sivulla).
 Valitse moduuli `Data management/Scenario/Import scenario`.
 `Folder containing scenario to import:` -valikossa, valitse jakokansiosta `Verkot` yksi kansio, esim. `2018`.
 Valitse olemassa oleva skenaarionumero (`Overwrite scenario`) tai luo uusi.
@@ -86,4 +86,4 @@ Moduuli lukee skenaarioon tarpeelliset tiedot tiedostoista
 
 ## Muut lähtötiedot
 
-Muut tarvittavat lähtötiedot (mm. maankäyttö, kustannukset, pohjakysyntä) ajetaan automaattisesti sisään ennusteprosessin aikana. Lähtötiedot kuvaavat mallin estimointivuoden tilannetta, ja lisäksi malliin syötetään syöttötietoja, jotka kuvaavat ennusteskenaarion tilannetta (lisätietoja [täällä](mallin_lahtotietotiedostot.md)).
+Muut tarvittavat lähtötiedot (mm. maankäyttö, kustannukset, pohjakysyntä) ajetaan automaattisesti sisään ennusteprosessin aikana. Lähtötiedot kuvaavat mallin estimointivuoden tilannetta, ja lisäksi malliin syötetään syöttötietoja, jotka kuvaavat ennusteskenaarion tilannetta (lisätietoja [Lähtötiedot](mallin_lahtotietotiedostot.md)-sivulla).

--- a/docs/tulokset.md
+++ b/docs/tulokset.md
@@ -15,7 +15,7 @@ Huom! Jos ajat samassa Emme-pankissa useita Helmet-skenaarioita, tarkat matriisi
 jos config-tiedostoon on määritelty matriiseille omat tallennuspaikat (ks. [Mallijärjestelmän käyttö](mallitoiden_yleisohje.html)).
 
 Lisää tietoja kysyntämallien toiminnallisuuksista ja niiden tulosten merkityksestä saat
-[malliraportista](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).
+(KORJAA) [malliraportista](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).
 
 ## Tulokset verrattuna Helmet 4.1:een
 

--- a/docs/tulokset.md
+++ b/docs/tulokset.md
@@ -5,14 +5,14 @@ sort: 6
 
 # Tulokset
 
-Tulosten tallennuskansiopolku määritellään Helmet-käyttöliittymän projektiasetuksissa (ks. [ohjeet](kaytto-ohje.md)). 
+Tulosten tallennuskansiopolku määritellään Helmet-käyttöliittymän projektiasetuksissa (ks. "[Asennus](kaytto-ohje.md)"). 
 Kunkin Helmet-skenaarion (malliajon) tulokset tallentuvat kyseisen Helmet-skenaarion nimellä nimettyyn alikansioon. 
 Näihin kansioihin tallentuu kahdentyyppisiä tiedostoja matriiseja ja tekstitiedostoja, joita on kuvattu tässä ohjeessa tarkemmin.
 
 Näiden lisäksi sijoittelutulokset jäävät talteen Emme-pankkiin.
 Lisää tietoja sijoittelun tuloksista ja niiden analysoinnista löytyy Emmen dokumentaatiosta. 
 Huom! Jos ajat samassa Emme-pankissa useita Helmet-skenaarioita, tarkat matriisitulokset jäävät Emmeen talteen vain, 
-jos config-tiedostoon on määritelty matriiseille omat tallennuspaikat (ks. [ohjeet](kaytto-ohje.md)).
+jos config-tiedostoon on määritelty matriiseille omat tallennuspaikat (ks. [Mallijärjestelmän käyttö](mallitoiden_yleisohje.html)).
 
 Lisää tietoja kysyntämallien toiminnallisuuksista ja niiden tulosten merkityksestä saat
 [malliraportista](https://staticfiles.hsl.fi/globalassets/julkaisuarkisto/2020/6_2020_helsingin_seudun_tyossakayntialueen_liikenne-ennustejarjestelman_kysyntamallit.pdf).

--- a/docs/tulokset.md
+++ b/docs/tulokset.md
@@ -130,8 +130,8 @@ mutta ne ovat autosijoittelussa taustaliikenteenä.
 | helsinki_cbd   | Helsingin kantakaupunki                         | 0 - 999          |
 | helsinki_other | Muu Helsinki                                    | 1 000 - 1 999    |
 | espoo_vant_kau | Muu pääkaupunkiseutu                            | 2 000 - 5 999    |
-| surrounding    | Kehyskunnat + Siuntio                           | 6 000 - 15 999   |
-| surround_train | Junaliikenteeseen <br /> tukeutuvat kehyskunnat + Siuntio | 6 000 - 6 999 <br /> 10 000 - 11 999 <br /> 13 000 - 14 999 <br /> 15 500 - 15 999 |
+| surrounding    | Kehyskunnat                           | 6 000 - 15 999   |
+| surround_train | Junaliikenteeseen <br /> tukeutuvat kehyskunnat | 6 000 - 6 999 <br /> 10 000 - 11 999 <br /> 13 000 - 14 999 <br /> 15 500 - 15 999 |
 | surround_other | Muut kehyskunnat                                | 7 000 - 9 999 <br /> 12 000 - 12 999 <br /> 15 000 - 15 499 |
 | peripheral     | Ympäryskunnat                                   | 16 000 - 30 999  |
 


### PR DESCRIPTION
Käyttöohje luettu Emme-verkon ohjetta lukuun ottamatta. Commiteissa:
- typokorjauksia
- linkkien muotoiluja: "lue lisää tästä" -> "lue lisää Asennus-sivulta" yms.
- Siuntio määritelmällisesti kehyskunta
- poistettu vanhoja huomioita, jotka periytyi jo monen vuoden takaa vanhoista HELMET- ja UI-versioista
- poistettu henkilöiden nimet

Huomioita:
- En lukenut Emme-verkon ohjeita
- Tulokset-sivu käytävä läpi ja päivitettävä yhdessä malliajon tuloskansion kanssa, että menee oikein (kuka?)
- Tulokset-sivulta voinee poistaa ne "Uusi HELMET-versiossa 4.0.4" -tyyppiset, koska ovat jo niin vanhoja uutisia
- Voiko yhteissähköpostin laittaa jotenkin tietoturvallisesti esille? (kuka varmistaa tietoturvalta/viestinnältä?)